### PR TITLE
Add wrapSelection.pattern command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"icon": "icon.png",
 	"activationEvents": [
 		"onCommand:wrapSelection",
+		"onCommand:wrapSelection.pattern",
 		"onCommand:wrapSelection.quote.single",
 		"onCommand:wrapSelection.quote.double",
 		"onCommand:wrapSelection.quote.french",
@@ -38,6 +39,10 @@
 			{
 				"command": "wrapSelection",
 				"title": "Wrap selected text"
+			},
+			{
+				"command": "wrapSelection.pattern",
+				"title": "Wrap selected text using custom pattern"
 			},
 			{
 				"command": "wrapSelection.quote.single",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, TextEdit, window } from "vscode";
+import { commands, ExtensionContext, window } from "vscode";
 import wrap from "./wrap";
 
 const wrapSelection = (editor, symbol) => {
@@ -20,12 +20,23 @@ const wrapSelection = (editor, symbol) => {
 };
 
 export function activate(context: ExtensionContext) {
+
 	context.subscriptions.push(commands.registerCommand("wrapSelection", async () => {
 		const { activeTextEditor: editor } = window;
 
 		const symbol = await window.showInputBox({ placeHolder: "symbols" });
 		wrapSelection(editor, symbol);
 	}));
+
+	context.subscriptions.push(
+		commands.registerCommand(
+			"wrapSelection.pattern",
+			(symbol) => {
+				const { activeTextEditor: editor } = window;
+				wrapSelection(editor, symbol);
+			},
+		),
+	);
 
 	context.subscriptions.push(
 		commands.registerCommand(


### PR DESCRIPTION
The pattern command allows you to add keyboard shortcuts to a pattern that has been defined in the wrapSelection.patterns setting.

Example:

```json
// settings.json
{
  "wrapSelection.patterns": {
    "translate": "{{ '${text}' | translate }}"
  }
}
```

```json
// keybindings.json
[
    {
        "key": "ctrl+shift+t",
        "command": "wrapSelection.pattern",
        "args": "translate",
        "when": "editorHasSelection && editorTextFocus"
    }
]
```

```js
//select the text then ctrl+shift+f
This text

//results:
{{ 'This text' | translate }}
```