### PR TITLE
Support asymmetrical selection wrapping with placeholder "$&"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Through «Wrap selected text» you can also use multiple symbols, i.e.:
  - `<!--` → `<!--text-->`
  - `<%` → `<%text%>`
 
+### Instantly wrap text symmetrically or asymmetrically, e.g.:
+
+ - `***` → `***text***`
+ - `func($&)` → `func(text)`
+
 ### Custom user patterns
 ![user patterns](https://github.com/gko/wrap/raw/master/userDefined.gif)
 

--- a/src/__tests__/wrap.test.ts
+++ b/src/__tests__/wrap.test.ts
@@ -66,6 +66,15 @@ describe("wrap", () => {
 				assert.equal(wrap("test", "%}"), "{%test%}");
 			});
 		});
+
+		it("should wrap with $& replaced with the selections", () => {
+			// single $& get replaced to selected text
+			assert.equal(wrap("test", "f($&)"), "f(test)");
+			// replace multiple $&
+			assert.equal(wrap("test", "f($&, $&)"), "f(test, test)");
+			// check that $& $1 $2 in anywhere (except $& in replacement) are just replaced literally, i.e. no special expansion
+			assert.equal(wrap("(test) $& $1", "f($&) + $2"), "f((test) $& $1) + $2");
+		});
 	});
 
 	describe("should correctly wrap with custom pattern", () => {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -33,7 +33,14 @@ const wrap = (text, pattern) => {
 		case "{{{": case "}}}": return `{{{${text}}}}`;
 		case "«": case "»": return `«${text}»`;
 		case "<!--": case "--!>": return `<!--${text}--!>`;
-		default: return `${pattern}${text}${pattern}`;
+		default:
+			if (pattern.indexOf('$&') !== -1) {
+				// Perform non-symmetric selection wrapping.
+				// - "$&" is used as a placeholder for the selected text, e.g. wrap("text", "f($&, ...)") gives "f(text, ...)". Same placeholder as JavaScript's strings' replace().
+				// - Using "$&" but not "${text}" because the latter is too long to be used as an unsaved quick wrap expression.
+				return pattern.split('$&').join(text);
+			}
+			return `${pattern}${text}${pattern}`;
 	}
 };
 


### PR DESCRIPTION
I would like this great utility also support on-the-fly asymmetrical selection wrapping with placeholder "$&".

E.g. Run "Wrap selected text" and enter `func($&)` --> a previously selected text `TEXT` will be replaced to `func(TEXT)`

Remark:
* "$&" is referencing the JavaScript strings replacement placeholder for the target to replace.
* The reason to use "$&" but not "${text}" as in rules settings is because the latter is too long to be used as an unsaved quick wrap expression.